### PR TITLE
Update handling of web-scrape caching

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,13 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      {
+        "include": "../config/*.*",
+        "outDir": "dist/config",
+        "watchAssets": true
+      }
+    ]
   }
 }

--- a/src/services/web-scrape/web-scrape.local.ts
+++ b/src/services/web-scrape/web-scrape.local.ts
@@ -18,13 +18,24 @@ const getCache = async (): Promise<SearchResultCache> => {
     }
 
     const fileContent = await promises.readFile(filepath)
+        .catch(err => {
+            console.log(`Error loading web scrape cache (${filepath})`, err)
+
+            return '{}'
+        })
         .then(buf => buf.toString())
 
     return JSON.parse(fileContent);
 }
 
 const writeCache = async (cache: SearchResultCache): Promise<void> => {
-    return promises.writeFile(filepath, JSON.stringify(cache, null, ' '));
+    return promises
+        .writeFile(filepath, JSON.stringify(cache, null, ' '))
+        .catch(err => {
+            console.log(`Error saving web scrape cache (${filepath})`, err)
+
+            return undefined
+        });
 }
 
 export class WebScrapeLocal implements WebScrapeWritableApi {


### PR DESCRIPTION
- Log error but don't fail if unable to read cache file
- Update build process to include cache file in build output